### PR TITLE
feat(cis): lookup GH user from whoami

### DIFF
--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -16,7 +16,7 @@ People data source
 terraform {
   required_providers {
     cis = {
-      source = "registry.terraform.io/mozilla/cis"
+      source = "registry.opentofu.org/mozilla/cis"
     }
   }
 }

--- a/examples/data-sources/cis_people/data-source.tf
+++ b/examples/data-sources/cis_people/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     cis = {
-      source = "registry.terraform.io/mozilla/cis"
+      source = "registry.opentofu.org/mozilla/cis"
     }
   }
 }

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -145,7 +145,13 @@ func (d *PeopleDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if person.Identities.GithubIDV4 != nil {
 		data.GitHub_Node_Id = types.StringValue(person.Identities.GithubIDV4.Value)
 	}
-	data.GitHub_Username = types.StringValue(person.Usernames.Values.GitHubUsername)
+	githubUsername := person.Usernames.Values.GitHubUsername
+	if person.Identities.GithubIDV3 != nil && person.Identities.GithubIDV3.Value != "" {
+		if username, err := d.client.GetGithubUsernameByNodeID(ctx, person.Identities.GithubIDV3.Value); err == nil {
+			githubUsername = username
+		}
+	}
+	data.GitHub_Username = types.StringValue(githubUsername)
 	data.Mozilliansorg_Groups, diags = types.ListValueFrom(ctx, types.StringType, person.AccessInformation.Mozilliansorg.List)
 	for _, d := range diags {
 		resp.Diagnostics.Append(d)

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -56,13 +56,14 @@ func (client *Client) GetAccessToken(ctx context.Context) error {
 
 	return err
 }
+
 /*
-WORKAROUND: hit the dino-park whoami endpoint to get Github username from ID since cis has stale data (MZCLD-3067) 
+WORKAROUND: hit the dino-park whoami endpoint to get Github username from ID since cis has stale data (MZCLD-3067)
 https://github.com/mozilla-iam/dino-park-whoami/blob/377130f75a69efc52a28de8b88ca075b6dbdca9b/src/github/app.rs#L62
 TODO: Fix this by doing one of:
- - Move this lookup upstream to fix cis staleness https://github.com/mozilla-iam/cis/blob/master/python-modules/cis_publisher/cis_publisher/auth0.py#L311
- - Hit Github directly instead of whoami
- - Hope https://github.com/integrations/terraform-provider-github/pull/3436 gets merged, do this lookup in TF
+  - Move this lookup upstream to fix cis staleness https://github.com/mozilla-iam/cis/blob/master/python-modules/cis_publisher/cis_publisher/auth0.py#L311
+  - Hit Github directly instead of whoami
+  - Hope https://github.com/integrations/terraform-provider-github/pull/3436 gets merged, do this lookup in TF
 */
 func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 string) (string, error) {
 	httpReq, err := http.NewRequest("GET", "https://people.mozilla.org/whoami/github/username/"+githubIDV3, nil)

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/oauth2/clientcredentials"
@@ -81,9 +80,14 @@ func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 
 		return "", err
 	}
 
-	var username string
-	if err := json.Unmarshal(respBody, &username); err != nil {
-		username = strings.TrimSpace(string(respBody))
+	var result map[string]string
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("failed to parse GitHub username response: %w", err)
+	}
+
+	username, ok := result["username"]
+	if !ok {
+		return "", fmt.Errorf("GitHub username response missing 'username' key")
 	}
 
 	return username, nil

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/oauth2/clientcredentials"
@@ -55,6 +56,37 @@ func (client *Client) GetAccessToken(ctx context.Context) error {
 	}
 
 	return err
+}
+
+func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 string) (string, error) {
+	httpReq, err := http.NewRequest("GET", "https://people.mozilla.org/whoami/github/username/"+githubIDV3, nil)
+	if err != nil {
+		return "", err
+	}
+
+	httpResp, err := client.httpClient.Do(httpReq)
+	tflog.Info(ctx, fmt.Sprintf("HTTP Request: %#v", httpReq))
+	if err != nil {
+		return "", err
+	}
+
+	if httpResp.StatusCode >= 400 {
+		return "", fmt.Errorf("people.mozilla.org responded with status code %d", httpResp.StatusCode)
+	}
+
+	defer httpResp.Body.Close()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var username string
+	if err := json.Unmarshal(respBody, &username); err != nil {
+		username = strings.TrimSpace(string(respBody))
+	}
+
+	return username, nil
 }
 
 func (client *Client) GetPersonByEmail(ctx context.Context, email string) (*Person, error) {

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -56,14 +56,14 @@ func (client *Client) GetAccessToken(ctx context.Context) error {
 
 	return err
 }
-
-# WORKAROUND: hit the dino-park whoami endpoint to get Github username from IDV3 since auth0 has stale data (MZCLD-3067) 
-## https://github.com/mozilla-iam/dino-park-whoami/blob/377130f75a69efc52a28de8b88ca075b6dbdca9b/src/github/app.rs#L62
-# TODO: Fix this by doing one of:
-## Move this lookup upstream to fix cis staleness https://github.com/mozilla-iam/cis/blob/master/python-modules/cis_publisher/cis_publisher/auth0.py#L311
-## Hit Github directly instead of whoami
-## Hope https://github.com/integrations/terraform-provider-github/pull/3436 gets merged, do this lookup in TF
-
+/*
+WORKAROUND: hit the dino-park whoami endpoint to get Github username from ID since cis has stale data (MZCLD-3067) 
+https://github.com/mozilla-iam/dino-park-whoami/blob/377130f75a69efc52a28de8b88ca075b6dbdca9b/src/github/app.rs#L62
+TODO: Fix this by doing one of:
+ - Move this lookup upstream to fix cis staleness https://github.com/mozilla-iam/cis/blob/master/python-modules/cis_publisher/cis_publisher/auth0.py#L311
+ - Hit Github directly instead of whoami
+ - Hope https://github.com/integrations/terraform-provider-github/pull/3436 gets merged, do this lookup in TF
+*/
 func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 string) (string, error) {
 	httpReq, err := http.NewRequest("GET", "https://people.mozilla.org/whoami/github/username/"+githubIDV3, nil)
 	if err != nil {

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -69,7 +69,7 @@ func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 
 		return "", err
 	}
 
-	if httpResp.StatusCode >= 400 {
+	if httpResp.StatusCode != 200 {
 		return "", fmt.Errorf("people.mozilla.org responded with status code %d", httpResp.StatusCode)
 	}
 

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -57,6 +57,13 @@ func (client *Client) GetAccessToken(ctx context.Context) error {
 	return err
 }
 
+# WORKAROUND: hit the dino-park whoami endpoint to get Github username from IDV3 since auth0 has stale data (MZCLD-3067) 
+## https://github.com/mozilla-iam/dino-park-whoami/blob/377130f75a69efc52a28de8b88ca075b6dbdca9b/src/github/app.rs#L62
+# TODO: Fix this by doing one of:
+## Move this lookup upstream to fix cis staleness https://github.com/mozilla-iam/cis/blob/master/python-modules/cis_publisher/cis_publisher/auth0.py#L311
+## Hit Github directly instead of whoami
+## Hope https://github.com/integrations/terraform-provider-github/pull/3436 gets merged, do this lookup in TF
+
 func (client *Client) GetGithubUsernameByNodeID(ctx context.Context, githubIDV3 string) (string, error) {
 	httpReq, err := http.NewRequest("GET", "https://people.mozilla.org/whoami/github/username/"+githubIDV3, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes [stale github username bug](https://mozilla-hub.atlassian.net/browse/MZCLD-3067) by looking up GH usernames from the dino park `whoami` endpoint, which isn't stale.

Falls back to old method if lookup fails or if V3 ID is not present for a user.

Validated w/ cbeck user - with 1.0.0:
```
Changes to Outputs:
  + example = {
      + email                = "cbeck@mozilla.com"
      + github_node_id       = "MDQ6VXNlcjY0ODgxNTU3"
      + github_username      = "chelseybeck"

```
With these changes:
```
Changes to Outputs:
  + example = {
      + email                = "cbeck@mozilla.com"
      + github_node_id       = "MDQ6VXNlcjY0ODgxNTU3"
      + github_username      = "chelseyklein"
```