### PR TITLE
feat: Add provider version to HTTP user agent

### DIFF
--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -24,15 +25,34 @@ type Client struct {
 	auth0AccessToken string
 }
 
-func NewClient(auth0ClientID string, auth0ClientSecret string, auth0Audience string, auth0Endpoint string, auth0Scopes []string, personEndpoint string) *Client {
+// userAgentRoundTripper sets a User-Agent header on every outbound request that
+// does not already specify one, then delegates to the wrapped RoundTripper.
+type userAgentRoundTripper struct {
+	userAgent string
+	next      http.RoundTripper
+}
+
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Per the RoundTripper contract the request must not be mutated, so clone it
+	// before adding the header.
+	r := req.Clone(req.Context())
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", rt.userAgent)
+	}
+	return rt.next.RoundTrip(r)
+}
+
+func NewClient(auth0ClientID string, auth0ClientSecret string, auth0Audience string, auth0Endpoint string, auth0Scopes []string, personEndpoint string, userAgent string) *Client {
 	c := &Client{
 		auth0ClientID:     auth0ClientID,
 		auth0ClientSecret: auth0ClientSecret,
 		auth0Audience:     auth0Audience,
 		auth0Endpoint:     auth0Endpoint,
 		auth0Scopes:       auth0Scopes,
-		httpClient:        &http.Client{},
-		personEndpoint:    personEndpoint,
+		httpClient: &http.Client{
+			Transport: &userAgentRoundTripper{userAgent: userAgent, next: http.DefaultTransport},
+		},
+		personEndpoint: personEndpoint,
 	}
 
 	return c
@@ -46,6 +66,10 @@ func (client *Client) GetAccessToken(ctx context.Context) error {
 		Scopes:         client.auth0Scopes,
 		TokenURL:       client.auth0Endpoint,
 	}
+
+	// Use our own HTTP client for the token request so it carries the same
+	// User-Agent header as the Person API calls.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, client.httpClient)
 
 	oauth_token, err := oauth2_config.Token(ctx)
 	tflog.Info(ctx, fmt.Sprintf("HTTP Request: %#v", oauth_token))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"terraform-provider-cis/internal/provider/person_api"
 
@@ -146,7 +148,7 @@ func (p *CISProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		// "display:authenticated",
 		// "display:vouched",
 		"display:staff",
-	}, person_endpoint)
+	}, person_endpoint, buildUserAgent(p.version, req.TerraformVersion))
 
 	err := client.GetAccessToken(ctx)
 	if err != nil {
@@ -182,4 +184,37 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+// buildUserAgent constructs the User-Agent header sent on all outbound API
+// requests. It identifies the provider version and whether it is a development
+// build, the Go toolchain and platform the provider was compiled with, and the
+// version of the Terraform/OpenTofu CLI making the request.
+//
+// providerVersion is "dev" for local builds and "test" during acceptance
+// testing; both are reported as development builds. terraformVersion is supplied
+// by the CLI at configure time (OpenTofu reports its version through the same
+// field, so the CLI product cannot be distinguished here — only the version).
+func buildUserAgent(providerVersion string, terraformVersion string) string {
+	channel := "release"
+	if providerVersion == "" || providerVersion == "dev" || providerVersion == "test" {
+		channel = "dev"
+	}
+
+	if providerVersion == "" {
+		providerVersion = "unknown"
+	}
+	if terraformVersion == "" {
+		terraformVersion = "unknown"
+	}
+
+	return fmt.Sprintf(
+		"terraform-provider-cis/%s (%s) Terraform/%s Go/%s (%s/%s)",
+		providerVersion,
+		channel,
+		terraformVersion,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
 }

--- a/internal/provider/user_agent_test.go
+++ b/internal/provider/user_agent_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildUserAgent(t *testing.T) {
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	goVersion := runtime.Version()
+
+	cases := []struct {
+		name             string
+		providerVersion  string
+		terraformVersion string
+		want             string
+	}{
+		{
+			name:             "release build",
+			providerVersion:  "1.2.3",
+			terraformVersion: "1.9.0",
+			want:             "terraform-provider-cis/1.2.3 (release) Terraform/1.9.0 Go/" + goVersion + " (" + platform + ")",
+		},
+		{
+			name:             "dev build",
+			providerVersion:  "dev",
+			terraformVersion: "1.9.0",
+			want:             "terraform-provider-cis/dev (dev) Terraform/1.9.0 Go/" + goVersion + " (" + platform + ")",
+		},
+		{
+			name:             "test build",
+			providerVersion:  "test",
+			terraformVersion: "1.6.0",
+			want:             "terraform-provider-cis/test (dev) Terraform/1.6.0 Go/" + goVersion + " (" + platform + ")",
+		},
+		{
+			name:             "empty versions",
+			providerVersion:  "",
+			terraformVersion: "",
+			want:             "terraform-provider-cis/unknown (dev) Terraform/unknown Go/" + goVersion + " (" + platform + ")",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUserAgent(tc.providerVersion, tc.terraformVersion)
+			if got != tc.want {
+				t.Errorf("buildUserAgent(%q, %q) = %q, want %q", tc.providerVersion, tc.terraformVersion, got, tc.want)
+			}
+			if !strings.HasPrefix(got, "terraform-provider-cis/") {
+				t.Errorf("user agent %q missing product prefix", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the provider version, go platform, and terraform version to the HTTP user agent for easier debugging/blaming

- MZCLD-3466