### PR TITLE
feat: Add GitHub user ID attribute

### DIFF
--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -43,6 +43,7 @@ output "example" {
 
 ### Read-Only
 
+- `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -29,6 +29,7 @@ type PeopleDataSource struct {
 // PeopleDataSourceModel describes the data source data model.
 type PeopleDataSourceModel struct {
 	Email                types.String `tfsdk:"email"`
+	GitHub_Id            types.String `tfsdk:"github_id"`
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
 	Id                   types.String `tfsdk:"id"`
@@ -49,6 +50,10 @@ func (d *PeopleDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"email": schema.StringAttribute{
 				MarkdownDescription: "People email address",
 				Optional:            true,
+			},
+			"github_id": schema.StringAttribute{
+				MarkdownDescription: "GitHub ID",
+				Computed:            true,
 			},
 			"github_node_id": schema.StringAttribute{
 				MarkdownDescription: "GitHub node ID",
@@ -142,6 +147,9 @@ func (d *PeopleDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	// save into the Terraform state.
 	data.Id = types.StringValue(person.UserID.Value)
 
+	if person.Identities.GithubIDV3 != nil {
+		data.GitHub_Id = types.StringValue(person.Identities.GithubIDV3.Value)
+	}
 	if person.Identities.GithubIDV4 != nil {
 		data.GitHub_Node_Id = types.StringValue(person.Identities.GithubIDV4.Value)
 	}

--- a/internal/provider/people_data_source_test.go
+++ b/internal/provider/people_data_source_test.go
@@ -25,6 +25,11 @@ func TestAccExampleDataSource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
+						tfjsonpath.New("github_id"),
+						knownvalue.StringExact("578466"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
 						tfjsonpath.New("github_node_id"),
 						knownvalue.StringExact("MDQ6VXNlcjU3ODQ2Ng=="),
 					),


### PR DESCRIPTION
This PR adds the GitHub user ID attribute to the `cis_person` data source

- MZCLD-3466