### PR TITLE
chore: Test newer versions of opentofu and terraform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,13 +63,13 @@ jobs:
       matrix:
         tool:
           - name: tofu
-            version: '1.10.*'
-          - name: tofu
             version: '1.11.*'
-          - name: terraform
-            version: '1.13.*'
+          - name: tofu
+            version: '1.12.*'
           - name: terraform
             version: '1.14.*'
+          - name: terraform
+            version: '1.15.*'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0


### PR DESCRIPTION
This PR tests newer versions of opentofu and terraform - the current and one oldest release.

MZCLD-3466