### PR TITLE
feat: Add ldap_groups attribute

### DIFF
--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -45,4 +45,5 @@ output "example" {
 
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
+- `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -32,6 +32,7 @@ type PeopleDataSourceModel struct {
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
 	Id                   types.String `tfsdk:"id"`
+	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Mozilliansorg_Groups types.List   `tfsdk:"mozilliansorg_groups"`
 	Username             types.String `tfsdk:"username"`
 }
@@ -61,6 +62,11 @@ func (d *PeopleDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"id": schema.StringAttribute{
 				MarkdownDescription: "People user identifier",
 				Optional:            true,
+			},
+			"ldap_groups": schema.ListAttribute{
+				ElementType:         types.StringType,
+				MarkdownDescription: "LDAP groups the user is in",
+				Computed:            true,
 			},
 			"mozilliansorg_groups": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -152,6 +158,13 @@ func (d *PeopleDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 	}
 	data.GitHub_Username = types.StringValue(githubUsername)
+
+	ldapGroups, ldapDiags := types.ListValueFrom(ctx, types.StringType, person.AccessInformation.LDAP.List)
+	for _, d := range ldapDiags {
+		resp.Diagnostics.Append(d)
+	}
+	data.LDAP_Groups = ldapGroups
+
 	data.Mozilliansorg_Groups, diags = types.ListValueFrom(ctx, types.StringType, person.AccessInformation.Mozilliansorg.List)
 	for _, d := range diags {
 		resp.Diagnostics.Append(d)

--- a/internal/provider/people_data_source_test.go
+++ b/internal/provider/people_data_source_test.go
@@ -38,14 +38,20 @@ func TestAccExampleDataSource(t *testing.T) {
 						tfjsonpath.New("id"),
 						knownvalue.StringExact("ad|Mozilla-LDAP|jbuckley"),
 					),
-					// TODO need to output sorted list before I can easily test this attribute
-					// statecheck.ExpectKnownValue(
-					// 	"data.cis_people.test",
-					// 	tfjsonpath.New("mozilliansorg_groups"),
-					// 	knownvalue.ListPartial(map[int]knownvalue.Check{
-					// 		0: knownvalue.StringExact("value1"),
-					// 	}),
-					// ),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("ldap_groups"),
+						knownvalue.ListPartial(map[int]knownvalue.Check{
+							0: knownvalue.StringExact("inventory"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("mozilliansorg_groups"),
+						knownvalue.ListPartial(map[int]knownvalue.Check{
+							0: knownvalue.StringExact("aws_billing_access"),
+						}),
+					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
 						tfjsonpath.New("username"),

--- a/internal/provider/person_api/api.go
+++ b/internal/provider/person_api/api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/oauth2"
@@ -157,12 +158,24 @@ func (client *Client) GetPersonByEmail(ctx context.Context, email string) (*Pers
 		return nil, err
 	}
 
-	// Convert map keys into a list of strings
-	keys := make([]string, 0, len(person.AccessInformation.Mozilliansorg.Values))
-	for key := range person.AccessInformation.Mozilliansorg.Values {
-		keys = append(keys, key)
-	}
-	person.AccessInformation.Mozilliansorg.List = keys
+	flattenAccessInformation(&person)
 
 	return &person, nil
+}
+
+// flattenAccessInformation converts the Mozilliansorg and LDAP access information
+// Values maps into lists of group names stored in their respective List fields.
+func flattenAccessInformation(person *Person) {
+	person.AccessInformation.Mozilliansorg.List = mapKeys(person.AccessInformation.Mozilliansorg.Values)
+	person.AccessInformation.LDAP.List = mapKeys(person.AccessInformation.LDAP.Values)
+}
+
+// mapKeys returns the keys of m as a slice of strings.
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }

--- a/internal/provider/person_api/person.go
+++ b/internal/provider/person_api/person.go
@@ -81,6 +81,7 @@ type LDAPAttribute struct {
 	Metadata  Metadata               `json:"metadata"`
 	Signature Signature              `json:"signature"`
 	Values    map[string]interface{} `json:"values"`
+	List      []string
 }
 
 type MozilliansorgAttribute struct {


### PR DESCRIPTION
This PR adds the `ldap_groups` attribute to `cis_people`. Also took the opportunity to sort the groups list so it's possible to test `mozilliansorg_groups` as well.

MZCLD-3466