### PR TITLE
feat: Configurable OAuth scopes, additional attributes

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -58,6 +58,7 @@ Read-Only:
 - `id` (String) People user identifier
 - `is_director` (Boolean) Whether the person is a director
 - `is_manager` (Boolean) Whether the person is a manager
+- `is_staff` (Boolean) Whether the person is Mozilla staff
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `manager_email` (String) Primary work email of the person's manager

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -56,6 +56,7 @@ Read-Only:
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
 - `id` (String) People user identifier
+- `is_director` (Boolean) Whether the person is a director
 - `is_manager` (Boolean) Whether the person is a manager
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -50,6 +50,7 @@ output "example" {
 
 Read-Only:
 
+- `active` (Boolean) Whether the person's account is active
 - `email` (String) People email address
 - `first_name` (String) First name
 - `github_id` (String) GitHub ID

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -59,5 +59,6 @@ Read-Only:
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
+- `team` (String) Team
 - `title` (String) Job title
 - `username` (String) People username

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -51,6 +51,7 @@ output "example" {
 Read-Only:
 
 - `email` (String) People email address
+- `first_name` (String) First name
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -51,6 +51,7 @@ output "example" {
 Read-Only:
 
 - `active` (Boolean) Whether the person's account is active
+- `cost_center` (Number) Cost center the person belongs to
 - `email` (String) People email address
 - `first_name` (String) First name
 - `github_id` (String) GitHub ID

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -56,6 +56,7 @@ Read-Only:
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
 - `id` (String) People user identifier
+- `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
 - `username` (String) People username

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -58,6 +58,7 @@ Read-Only:
 - `id` (String) People user identifier
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
+- `manager_email` (String) Primary work email of the person's manager
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
 - `team` (String) Team
 - `title` (String) Job title

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -67,3 +67,4 @@ Read-Only:
 - `team` (String) Team
 - `title` (String) Job title
 - `username` (String) People username
+- `worker_type` (String) Worker type (e.g. Employee)

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -56,6 +56,7 @@ Read-Only:
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
 - `id` (String) People user identifier
+- `is_manager` (Boolean) Whether the person is a manager
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `manager_email` (String) Primary work email of the person's manager

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -59,4 +59,5 @@ Read-Only:
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
+- `title` (String) Job title
 - `username` (String) People username

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -50,4 +50,5 @@ output "example" {
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
+- `team` (String) Team
 - `title` (String) Job title

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -57,3 +57,4 @@ output "example" {
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
 - `team` (String) Team
 - `title` (String) Job title
+- `worker_type` (String) Worker type (e.g. Employee)

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -47,6 +47,7 @@ output "example" {
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
+- `is_manager` (Boolean) Whether the person is a manager
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `manager_email` (String) Primary work email of the person's manager

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -43,6 +43,7 @@ output "example" {
 
 ### Read-Only
 
+- `first_name` (String) First name
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -43,6 +43,7 @@ output "example" {
 
 ### Read-Only
 
+- `active` (Boolean) Whether the person's account is active
 - `first_name` (String) First name
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -44,6 +44,7 @@ output "example" {
 ### Read-Only
 
 - `active` (Boolean) Whether the person's account is active
+- `cost_center` (Number) Cost center the person belongs to
 - `first_name` (String) First name
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -47,6 +47,7 @@ output "example" {
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
+- `is_director` (Boolean) Whether the person is a director
 - `is_manager` (Boolean) Whether the person is a manager
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -49,6 +49,7 @@ output "example" {
 - `github_username` (String) GitHub username
 - `is_director` (Boolean) Whether the person is a director
 - `is_manager` (Boolean) Whether the person is a manager
+- `is_staff` (Boolean) Whether the person is Mozilla staff
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `manager_email` (String) Primary work email of the person's manager

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -50,3 +50,4 @@ output "example" {
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
+- `title` (String) Job title

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -47,5 +47,6 @@ output "example" {
 - `github_id` (String) GitHub ID
 - `github_node_id` (String) GitHub node ID
 - `github_username` (String) GitHub username
+- `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in

--- a/docs/data-sources/people.md
+++ b/docs/data-sources/people.md
@@ -49,6 +49,7 @@ output "example" {
 - `github_username` (String) GitHub username
 - `last_name` (String) Last name
 - `ldap_groups` (List of String) LDAP groups the user is in
+- `manager_email` (String) Primary work email of the person's manager
 - `mozilliansorg_groups` (List of String) Mozilliansorg groups the user is in
 - `team` (String) Team
 - `title` (String) Job title

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,4 +31,5 @@ provider "cis" {}
 - `auth0_client_id` (String, Sensitive) Auth0 client ID
 - `auth0_client_secret` (String, Sensitive) Auth0 client secret
 - `auth0_endpoint` (String) Auth0 endpoint
+- `auth0_scopes` (List of String) Auth0 OAuth2 scopes to request. May also be set with the `AUTH0_SCOPES` environment variable (space-separated). If unset, no scopes are requested and the access token is granted the scopes the client was registered with.
 - `person_endpoint` (String) CIS person endpoint

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -34,6 +34,7 @@ type PeopleDataSourceModel struct {
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
 	Id                   types.String `tfsdk:"id"`
+	Is_Director          types.Bool   `tfsdk:"is_director"`
 	Is_Manager           types.Bool   `tfsdk:"is_manager"`
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
@@ -84,6 +85,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"id": queryField("People user identifier"),
+		"is_director": schema.BoolAttribute{
+			MarkdownDescription: "Whether the person is a director",
+			Computed:            true,
+		},
 		"is_manager": schema.BoolAttribute{
 			MarkdownDescription: "Whether the person is a manager",
 			Computed:            true,
@@ -248,6 +253,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 		data.Manager_Email = types.StringValue(managerEmail)
 	}
 
+	data.Is_Director = types.BoolValue(person.StaffInformation.Director.Value)
 	data.Is_Manager = types.BoolValue(person.StaffInformation.Manager.Value)
 	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -37,6 +37,7 @@ type PeopleDataSourceModel struct {
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Mozilliansorg_Groups types.List   `tfsdk:"mozilliansorg_groups"`
+	Team                 types.String `tfsdk:"team"`
 	Title                types.String `tfsdk:"title"`
 	Username             types.String `tfsdk:"username"`
 }
@@ -93,6 +94,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 		"mozilliansorg_groups": schema.ListAttribute{
 			ElementType:         types.StringType,
 			MarkdownDescription: "Mozilliansorg groups the user is in",
+			Computed:            true,
+		},
+		"team": schema.StringAttribute{
+			MarkdownDescription: "Team",
 			Computed:            true,
 		},
 		"title": schema.StringAttribute{
@@ -228,6 +233,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	diags.Append(groupDiags...)
 	data.Mozilliansorg_Groups = groups
 
+	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)
 
 	data.Username = types.StringValue(person.PrimaryUsername.Value)

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -28,6 +28,7 @@ type PeopleDataSource struct {
 
 // PeopleDataSourceModel describes the data source data model.
 type PeopleDataSourceModel struct {
+	Active               types.Bool   `tfsdk:"active"`
 	Email                types.String `tfsdk:"email"`
 	First_Name           types.String `tfsdk:"first_name"`
 	GitHub_Id            types.String `tfsdk:"github_id"`
@@ -68,6 +69,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 	}
 
 	return map[string]schema.Attribute{
+		"active": schema.BoolAttribute{
+			MarkdownDescription: "Whether the person's account is active",
+			Computed:            true,
+		},
 		"email": queryField("People email address"),
 		"first_name": schema.StringAttribute{
 			MarkdownDescription: "First name",
@@ -234,6 +239,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	var diags diag.Diagnostics
 
 	data.Id = types.StringValue(person.UserID.Value)
+	data.Active = types.BoolValue(person.Active.Value)
 	data.First_Name = types.StringValue(person.FirstName.Value)
 	data.Last_Name = types.StringValue(person.LastName.Value)
 

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -36,6 +36,7 @@ type PeopleDataSourceModel struct {
 	Id                   types.String `tfsdk:"id"`
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
+	Manager_Email        types.String `tfsdk:"manager_email"`
 	Mozilliansorg_Groups types.List   `tfsdk:"mozilliansorg_groups"`
 	Team                 types.String `tfsdk:"team"`
 	Title                types.String `tfsdk:"title"`
@@ -89,6 +90,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 		"ldap_groups": schema.ListAttribute{
 			ElementType:         types.StringType,
 			MarkdownDescription: "LDAP groups the user is in",
+			Computed:            true,
+		},
+		"manager_email": schema.StringAttribute{
+			MarkdownDescription: "Primary work email of the person's manager",
 			Computed:            true,
 		},
 		"mozilliansorg_groups": schema.ListAttribute{
@@ -232,6 +237,11 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	groups, groupDiags := types.ListValueFrom(ctx, types.StringType, person.AccessInformation.Mozilliansorg.List)
 	diags.Append(groupDiags...)
 	data.Mozilliansorg_Groups = groups
+
+	// managers_primary_work_email lives in the HRIS values map, which is untyped.
+	if managerEmail, ok := person.AccessInformation.Hris.Values["managers_primary_work_email"].(string); ok {
+		data.Manager_Email = types.StringValue(managerEmail)
+	}
 
 	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -45,6 +45,7 @@ type PeopleDataSourceModel struct {
 	Team                 types.String `tfsdk:"team"`
 	Title                types.String `tfsdk:"title"`
 	Username             types.String `tfsdk:"username"`
+	Worker_Type          types.String `tfsdk:"worker_type"`
 }
 
 func (d *PeopleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -130,6 +131,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"username": queryField("People username"),
+		"worker_type": schema.StringAttribute{
+			MarkdownDescription: "Worker type (e.g. Employee)",
+			Computed:            true,
+		},
 	}
 }
 
@@ -269,6 +274,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	data.Is_Staff = types.BoolValue(person.StaffInformation.Staff.Value)
 	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)
+	data.Worker_Type = types.StringValue(person.StaffInformation.WorkerType.Value)
 
 	data.Username = types.StringValue(person.PrimaryUsername.Value)
 

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -37,6 +37,7 @@ type PeopleDataSourceModel struct {
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Mozilliansorg_Groups types.List   `tfsdk:"mozilliansorg_groups"`
+	Title                types.String `tfsdk:"title"`
 	Username             types.String `tfsdk:"username"`
 }
 
@@ -92,6 +93,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 		"mozilliansorg_groups": schema.ListAttribute{
 			ElementType:         types.StringType,
 			MarkdownDescription: "Mozilliansorg groups the user is in",
+			Computed:            true,
+		},
+		"title": schema.StringAttribute{
+			MarkdownDescription: "Job title",
 			Computed:            true,
 		},
 		"username": queryField("People username"),
@@ -222,6 +227,8 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	groups, groupDiags := types.ListValueFrom(ctx, types.StringType, person.AccessInformation.Mozilliansorg.List)
 	diags.Append(groupDiags...)
 	data.Mozilliansorg_Groups = groups
+
+	data.Title = types.StringValue(person.StaffInformation.Title.Value)
 
 	data.Username = types.StringValue(person.PrimaryUsername.Value)
 

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -34,6 +34,7 @@ type PeopleDataSourceModel struct {
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
 	Id                   types.String `tfsdk:"id"`
+	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Mozilliansorg_Groups types.List   `tfsdk:"mozilliansorg_groups"`
 	Username             types.String `tfsdk:"username"`
@@ -79,6 +80,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"id": queryField("People user identifier"),
+		"last_name": schema.StringAttribute{
+			MarkdownDescription: "Last name",
+			Computed:            true,
+		},
 		"ldap_groups": schema.ListAttribute{
 			ElementType:         types.StringType,
 			MarkdownDescription: "LDAP groups the user is in",
@@ -200,6 +205,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 
 	data.Id = types.StringValue(person.UserID.Value)
 	data.First_Name = types.StringValue(person.FirstName.Value)
+	data.Last_Name = types.StringValue(person.LastName.Value)
 
 	if person.Identities.GithubIDV3 != nil {
 		data.GitHub_Id = types.StringValue(person.Identities.GithubIDV3.Value)

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"terraform-provider-cis/internal/provider/person_api"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
@@ -29,6 +30,7 @@ type PeopleDataSource struct {
 // PeopleDataSourceModel describes the data source data model.
 type PeopleDataSourceModel struct {
 	Active               types.Bool   `tfsdk:"active"`
+	Cost_Center          types.Int64  `tfsdk:"cost_center"`
 	Email                types.String `tfsdk:"email"`
 	First_Name           types.String `tfsdk:"first_name"`
 	GitHub_Id            types.String `tfsdk:"github_id"`
@@ -72,6 +74,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"active": schema.BoolAttribute{
 			MarkdownDescription: "Whether the person's account is active",
+			Computed:            true,
+		},
+		"cost_center": schema.Int64Attribute{
+			MarkdownDescription: "Cost center the person belongs to",
 			Computed:            true,
 		},
 		"email": queryField("People email address"),
@@ -245,6 +251,11 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 
 	data.Id = types.StringValue(person.UserID.Value)
 	data.Active = types.BoolValue(person.Active.Value)
+	// cost_center arrives as a float-formatted string (e.g. "14150.0"); expose it
+	// as an integer. Leave it null if it is absent or unparseable.
+	if costCenter, err := strconv.ParseFloat(person.StaffInformation.CostCenter.Value, 64); err == nil {
+		data.Cost_Center = types.Int64Value(int64(costCenter))
+	}
 	data.First_Name = types.StringValue(person.FirstName.Value)
 	data.Last_Name = types.StringValue(person.LastName.Value)
 

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -34,6 +34,7 @@ type PeopleDataSourceModel struct {
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
 	Id                   types.String `tfsdk:"id"`
+	Is_Manager           types.Bool   `tfsdk:"is_manager"`
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Manager_Email        types.String `tfsdk:"manager_email"`
@@ -83,6 +84,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"id": queryField("People user identifier"),
+		"is_manager": schema.BoolAttribute{
+			MarkdownDescription: "Whether the person is a manager",
+			Computed:            true,
+		},
 		"last_name": schema.StringAttribute{
 			MarkdownDescription: "Last name",
 			Computed:            true,
@@ -243,6 +248,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 		data.Manager_Email = types.StringValue(managerEmail)
 	}
 
+	data.Is_Manager = types.BoolValue(person.StaffInformation.Manager.Value)
 	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)
 

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -29,6 +29,7 @@ type PeopleDataSource struct {
 // PeopleDataSourceModel describes the data source data model.
 type PeopleDataSourceModel struct {
 	Email                types.String `tfsdk:"email"`
+	First_Name           types.String `tfsdk:"first_name"`
 	GitHub_Id            types.String `tfsdk:"github_id"`
 	GitHub_Node_Id       types.String `tfsdk:"github_node_id"`
 	GitHub_Username      types.String `tfsdk:"github_username"`
@@ -61,6 +62,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 
 	return map[string]schema.Attribute{
 		"email": queryField("People email address"),
+		"first_name": schema.StringAttribute{
+			MarkdownDescription: "First name",
+			Computed:            true,
+		},
 		"github_id": schema.StringAttribute{
 			MarkdownDescription: "GitHub ID",
 			Computed:            true,
@@ -194,6 +199,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 	var diags diag.Diagnostics
 
 	data.Id = types.StringValue(person.UserID.Value)
+	data.First_Name = types.StringValue(person.FirstName.Value)
 
 	if person.Identities.GithubIDV3 != nil {
 		data.GitHub_Id = types.StringValue(person.Identities.GithubIDV3.Value)

--- a/internal/provider/people_data_source.go
+++ b/internal/provider/people_data_source.go
@@ -36,6 +36,7 @@ type PeopleDataSourceModel struct {
 	Id                   types.String `tfsdk:"id"`
 	Is_Director          types.Bool   `tfsdk:"is_director"`
 	Is_Manager           types.Bool   `tfsdk:"is_manager"`
+	Is_Staff             types.Bool   `tfsdk:"is_staff"`
 	Last_Name            types.String `tfsdk:"last_name"`
 	LDAP_Groups          types.List   `tfsdk:"ldap_groups"`
 	Manager_Email        types.String `tfsdk:"manager_email"`
@@ -91,6 +92,10 @@ func PeopleAttributes(readOnly bool) map[string]schema.Attribute {
 		},
 		"is_manager": schema.BoolAttribute{
 			MarkdownDescription: "Whether the person is a manager",
+			Computed:            true,
+		},
+		"is_staff": schema.BoolAttribute{
+			MarkdownDescription: "Whether the person is Mozilla staff",
 			Computed:            true,
 		},
 		"last_name": schema.StringAttribute{
@@ -255,6 +260,7 @@ func personToModel(ctx context.Context, person *person_api.Person) (PeopleDataSo
 
 	data.Is_Director = types.BoolValue(person.StaffInformation.Director.Value)
 	data.Is_Manager = types.BoolValue(person.StaffInformation.Manager.Value)
+	data.Is_Staff = types.BoolValue(person.StaffInformation.Staff.Value)
 	data.Team = types.StringValue(person.StaffInformation.Team.Value)
 	data.Title = types.StringValue(person.StaffInformation.Title.Value)
 

--- a/internal/provider/people_data_source_test.go
+++ b/internal/provider/people_data_source_test.go
@@ -47,7 +47,7 @@ func TestAccExampleDataSource(t *testing.T) {
 						"data.cis_people.test",
 						tfjsonpath.New("ldap_groups"),
 						knownvalue.ListPartial(map[int]knownvalue.Check{
-							0: knownvalue.StringExact("inventory"),
+							0: knownvalue.StringExact("gh_access_mozilla"),
 						}),
 					),
 					statecheck.ExpectKnownValue(

--- a/internal/provider/people_data_source_test.go
+++ b/internal/provider/people_data_source_test.go
@@ -20,8 +20,18 @@ func TestAccExampleDataSource(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
+						tfjsonpath.New("active"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
 						tfjsonpath.New("email"),
 						knownvalue.StringExact("jbuckley@mozilla.com"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("first_name"),
+						knownvalue.StringExact("Jon"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
@@ -45,10 +55,35 @@ func TestAccExampleDataSource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
+						tfjsonpath.New("is_director"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("is_manager"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("is_staff"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("last_name"),
+						knownvalue.StringExact("Buckley"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
 						tfjsonpath.New("ldap_groups"),
 						knownvalue.ListPartial(map[int]knownvalue.Check{
 							0: knownvalue.StringExact("gh_access_mozilla"),
 						}),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("manager_email"),
+						knownvalue.StringExact("htahsildoost@mozilla.com"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
@@ -59,8 +94,23 @@ func TestAccExampleDataSource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
+						tfjsonpath.New("team"),
+						knownvalue.StringExact("Site Reliability Engineering (Hamid Tahsildoost)"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("title"),
+						knownvalue.StringExact("Senior Staff Software Engineer"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
 						tfjsonpath.New("username"),
 						knownvalue.StringExact("jbuck"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
+						tfjsonpath.New("worker_type"),
+						knownvalue.StringExact("Employee"),
 					),
 				},
 			},

--- a/internal/provider/people_data_source_test.go
+++ b/internal/provider/people_data_source_test.go
@@ -25,6 +25,11 @@ func TestAccExampleDataSource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"data.cis_people.test",
+						tfjsonpath.New("cost_center"),
+						knownvalue.Int64Exact(14150),
+					),
+					statecheck.ExpectKnownValue(
+						"data.cis_people.test",
 						tfjsonpath.New("email"),
 						knownvalue.StringExact("jbuckley@mozilla.com"),
 					),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"terraform-provider-cis/internal/provider/person_api"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -35,6 +36,7 @@ type CISProviderModel struct {
 	Auth0Endpoint     types.String `tfsdk:"auth0_endpoint"`
 	Auth0ClientID     types.String `tfsdk:"auth0_client_id"`
 	Auth0ClientSecret types.String `tfsdk:"auth0_client_secret"`
+	Auth0Scopes       types.List   `tfsdk:"auth0_scopes"`
 	PersonEndpoint    types.String `tfsdk:"person_endpoint"`
 }
 
@@ -63,6 +65,12 @@ func (p *CISProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				Optional:            true,
 				Sensitive:           true,
 			},
+			"auth0_scopes": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Description:         "Auth0 OAuth2 scopes to request. May also be set with the AUTH0_SCOPES environment variable (space-separated). If unset, no scopes are requested and the access token is granted the scopes the client was registered with.",
+				MarkdownDescription: "Auth0 OAuth2 scopes to request. May also be set with the `AUTH0_SCOPES` environment variable (space-separated). If unset, no scopes are requested and the access token is granted the scopes the client was registered with.",
+				Optional:            true,
+			},
 			"person_endpoint": schema.StringAttribute{
 				Description:         "CIS person endpoint",
 				MarkdownDescription: "CIS person endpoint",
@@ -88,6 +96,15 @@ func (p *CISProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	auth0_client_secret := os.Getenv("AUTH0_CLIENT_SECRET")
 	person_endpoint := os.Getenv("PERSON_ENDPOINT")
 
+	// Scopes default to none, in which case the access token is granted the
+	// scopes the client was registered with. They can be set with the
+	// AUTH0_SCOPES environment variable (space-separated) or, taking
+	// precedence, the auth0_scopes provider attribute.
+	auth0_scopes := []string{}
+	if env_scopes := strings.Fields(os.Getenv("AUTH0_SCOPES")); len(env_scopes) > 0 {
+		auth0_scopes = env_scopes
+	}
+
 	if data.Auth0Endpoint.ValueString() != "" {
 		auth0_endpoint = data.Auth0Endpoint.ValueString()
 	}
@@ -96,6 +113,12 @@ func (p *CISProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	}
 	if data.Auth0ClientSecret.ValueString() != "" {
 		auth0_client_secret = data.Auth0ClientSecret.ValueString()
+	}
+	if !data.Auth0Scopes.IsNull() {
+		resp.Diagnostics.Append(data.Auth0Scopes.ElementsAs(ctx, &auth0_scopes, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 	if data.PersonEndpoint.ValueString() != "" {
 		person_endpoint = data.PersonEndpoint.ValueString()
@@ -112,6 +135,7 @@ func (p *CISProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		"auth0_endpoint":      auth0_endpoint,
 		"auth0_client_id":     auth0_client_id,
 		"auth0_client_secret": auth0_client_secret,
+		"auth0_scopes":        auth0_scopes,
 		"person_endpoint":     person_endpoint,
 		"HasError()":          strconv.FormatBool(resp.Diagnostics.HasError()),
 	})
@@ -140,15 +164,7 @@ func (p *CISProvider) Configure(ctx context.Context, req provider.ConfigureReque
 
 	tflog.Info(ctx, "Configuring OAuth2 client")
 
-	client := person_api.NewClient(auth0_client_id, auth0_client_secret, "api.sso.mozilla.com", auth0_endpoint, []string{
-		// "classification:public",
-		"classification:workgroup",
-		// "display:none",
-		// "display:public",
-		// "display:authenticated",
-		// "display:vouched",
-		"display:staff",
-	}, person_endpoint, buildUserAgent(p.version, req.TerraformVersion))
+	client := person_api.NewClient(auth0_client_id, auth0_client_secret, "api.sso.mozilla.com", auth0_endpoint, auth0_scopes, person_endpoint, buildUserAgent(p.version, req.TerraformVersion))
 
 	err := client.GetAccessToken(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR allows configuring the oauth scopes in the provider and adds the following attributes:
- `first_name`
- `last_name`
- `title`
- `team`
- `manager_email`
- `is_manager`
- `is_director`
- `is_staff`
- `active`
- `worker_type`
- `cost_center`

## References

- MZCLD-3499